### PR TITLE
TW-12590 - Link spans to incoming W3C traceparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,37 @@ All image tags are pinned to exact patch versions in `docker-compose.yml`; bump 
 `composer.json` also pins `config.platform.php = "7.4"` so dependency resolution always targets the lowest supported PHP. Without that pin, running `composer install` under PHP 8 (as the `composer:2.9.8` image does) would pull dev deps that drop PHP 7.4 support — e.g. `doctrine/instantiator` ≥ 2.x uses PHP 8.3 typed-constant syntax and silently breaks the PHPUnit run on 7.4.
 
 Register an autoloader, or explicitly require the PHP files in `src/`, to consume the library from another project.
+
+## Changelog
+
+### 0.5.0
+
+- Link spans to an incoming W3C `traceparent` header via `Logger::createSpanLoggerFromTraceparent()` so PHP spans join the reverse-proxy's trace instead of a detached one.
+- `Span` accepts an optional `traceId`; nested `createSpanLogger` spans now inherit their parent's trace-id.
+
+### 0.4.0
+
+- Correct OTLP span timestamps to sub-second precision and add a per-call OTLP stopwatch (warns over a 200 ms threshold).
+- OTLP sending is always fire-and-forget — the queue drains at shutdown or via `OtlpSender::flushAll()`.
+- **Breaking:** dropped the OTLP singleton; an `OtlpSender` must be constructed and injected explicitly.
+- **Breaking:** renamed `CustomLogger` to `Logger` and extracted `OtlpLogRecord`.
+
+### 0.3.0
+
+- PHP 7.4 compatibility (`^7.4 || ^8.0`) and a Docker-based test workflow.
+
+### 0.2.2
+
+- Fixed span-logger config propagation (log level/format were passed by the wrong enum member).
+
+### 0.2.1
+
+- Fixed missing `otlpHttpHost` on `Span`.
+
+### 0.2.0
+
+- Added OpenTelemetry (OTLP) logging.
+
+### 0.1.0
+
+- Initial release: stdout logger with opinionated log levels and `text`/`json` formats.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ $requestSpanLog->debug('Request is over');
 $requestSpanLog->endSpan();
 ```
 
+### Linking to an incoming trace (`traceparent`)
+
+When a reverse-proxy (e.g. nginx `ngx_otel_module` with `otel_trace_context propagate`) injects a W3C `traceparent` header, root your request span on it so PHP spans join the proxy's trace instead of starting a detached one:
+
+```php
+$requestSpanLog = $log->createSpanLoggerFromTraceparent(
+    'request',
+    $_SERVER['HTTP_TRACEPARENT'] ?? null,
+    ['requestId' => 'Legodalf']
+);
+```
+
+The header (`version-traceId-spanId-flags`) is parsed and validated (32-hex trace-id, 16-hex span-id, both non-zero). On a valid header the span adopts the incoming trace-id and uses the proxy's span-id as its parent. A missing or malformed header falls back to a fresh trace without throwing. Nested `createSpanLogger` calls inherit the parent's trace-id, so the whole request shares one trace.
+
 ## Log levels
 
 - `error`: Unrecoverable error. Something is so broken the execution of the application can not continue.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "timewave/logger",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Logging library",
     "type": "library",
     "license": "MIT",

--- a/src/Classes/Logger.php
+++ b/src/Classes/Logger.php
@@ -89,9 +89,39 @@ class Logger implements LoggerInterface
             $this->serviceName,
             $context,
             $this->span !== null ? $this->span->id : null,
-            $this->otlpSender
+            $this->otlpSender,
+            $this->span !== null ? $this->span->traceId : null
         );
 
+        return $this->wrapSpan($span);
+    }
+
+    /**
+     * Root a span on an incoming W3C `traceparent` header so PHP spans join the
+     * proxy's trace. A missing or malformed header falls back to a fresh trace
+     * without throwing.
+     */
+    public function createSpanLoggerFromTraceparent(
+        string $name,
+        ?string $traceparent = null,
+        ?array $context = null
+    ): Logger {
+        $parsed = self::parseTraceparent($traceparent);
+
+        $span = new Span(
+            $name,
+            $this->serviceName,
+            $context,
+            $parsed['spanId'] ?? null,
+            $this->otlpSender,
+            $parsed['traceId'] ?? null
+        );
+
+        return $this->wrapSpan($span);
+    }
+
+    private function wrapSpan(Span $span): Logger
+    {
         return new Logger(
             $this->serviceName,
             $this->logLevel->name,
@@ -100,6 +130,33 @@ class Logger implements LoggerInterface
             $this->otlpSender,
             $span
         );
+    }
+
+    /**
+     * Parse "version-traceId-spanId-flags" into ['traceId','spanId'], or null
+     * when absent/invalid: 32-hex non-zero trace-id, 16-hex non-zero span-id.
+     */
+    private static function parseTraceparent(?string $traceparent): ?array
+    {
+        if ($traceparent === null) {
+            return null;
+        }
+
+        $parts = explode('-', trim($traceparent));
+        if (count($parts) < 4) {
+            return null;
+        }
+
+        [, $traceId, $spanId] = $parts;
+
+        if (!preg_match('/^[0-9a-f]{32}$/', $traceId) || $traceId === str_repeat('0', 32)) {
+            return null;
+        }
+        if (!preg_match('/^[0-9a-f]{16}$/', $spanId) || $spanId === str_repeat('0', 16)) {
+            return null;
+        }
+
+        return ['traceId' => $traceId, 'spanId' => $spanId];
     }
 
     public function endSpan(): void

--- a/src/Classes/Logger.php
+++ b/src/Classes/Logger.php
@@ -82,6 +82,7 @@ class Logger implements LoggerInterface
         $this->log(LogLevel::error(), $message, $context, $exception);
     }
 
+    /** @param array<string, scalar|\Stringable|null>|null $context span attributes (key => stringable value) */
     public function createSpanLogger(string $name, ?array $context = null): Logger
     {
         $span = new Span(
@@ -100,6 +101,8 @@ class Logger implements LoggerInterface
      * Root a span on an incoming W3C `traceparent` header so PHP spans join the
      * proxy's trace. A missing or malformed header falls back to a fresh trace
      * without throwing.
+     *
+     * @param array<string, scalar|\Stringable|null>|null $context span attributes (key => stringable value)
      */
     public function createSpanLoggerFromTraceparent(
         string $name,
@@ -135,6 +138,8 @@ class Logger implements LoggerInterface
     /**
      * Parse "version-traceId-spanId-flags" into ['traceId','spanId'], or null
      * when absent/invalid: 32-hex non-zero trace-id, 16-hex non-zero span-id.
+     *
+     * @return array{traceId: string, spanId: string}|null
      */
     private static function parseTraceparent(?string $traceparent): ?array
     {

--- a/src/Classes/Logger.php
+++ b/src/Classes/Logger.php
@@ -137,7 +137,8 @@ class Logger implements LoggerInterface
 
     /**
      * Parse "version-traceId-spanId-flags" into ['traceId','spanId'], or null
-     * when absent/invalid: 32-hex non-zero trace-id, 16-hex non-zero span-id.
+     * when absent/invalid: 2-hex version (not the reserved 'ff'), 32-hex non-zero
+     * trace-id, 16-hex non-zero span-id.
      *
      * @return array{traceId: string, spanId: string}|null
      */
@@ -152,7 +153,15 @@ class Logger implements LoggerInterface
             return null;
         }
 
-        [, $traceId, $spanId] = $parts;
+        [$version, $traceId, $spanId] = $parts;
+
+        if (!preg_match('/^[0-9a-f]{2}$/', $version) || $version === 'ff') {
+            return null;
+        }
+        // W3C: version 00 must have exactly 4 fields; unknown versions may carry more.
+        if ($version === '00' && count($parts) !== 4) {
+            return null;
+        }
 
         if (!preg_match('/^[0-9a-f]{32}$/', $traceId) || $traceId === str_repeat('0', 32)) {
             return null;

--- a/src/Classes/Span.php
+++ b/src/Classes/Span.php
@@ -27,7 +27,8 @@ class Span
         string $serviceName = 'my-app-logger',
         ?array $context = null,
         ?string $parentId = null,
-        ?OtlpSender $otlpSender = null
+        ?OtlpSender $otlpSender = null,
+        ?string $traceId = null
     ) {
         $this->name = $name;
         $this->serviceName = $serviceName;
@@ -36,7 +37,7 @@ class Span
         $this->otlpSender = $otlpSender;
 
         $this->id = $this->createSpanId();
-        $this->traceId = $this->createTraceId();
+        $this->traceId = $traceId ?? $this->createTraceId();
 
         $this->payload = [
             'resourceSpans' => [[

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -198,7 +198,11 @@ class LoggerTest extends LoggerSubprocessTestCase
         $outer = $log->createSpanLogger('outer');
         $inner = $outer->createSpanLogger('inner');
 
-        $this->assertSame($outer->getSpan()->traceId, $inner->getSpan()->traceId);
+        $outerSpan = $outer->getSpan();
+        $innerSpan = $inner->getSpan();
+        $this->assertNotNull($outerSpan);
+        $this->assertNotNull($innerSpan);
+        $this->assertSame($outerSpan->traceId, $innerSpan->traceId);
     }
 
     public function testCreateSpanLoggerFromTraceparentAdoptsTraceIdAndParentSpanId(): void
@@ -210,6 +214,7 @@ class LoggerTest extends LoggerSubprocessTestCase
         $root = $log->createSpanLoggerFromTraceparent('request', "00-{$traceId}-{$parentSpanId}-01");
 
         $span = $root->getSpan();
+        $this->assertNotNull($span);
         $this->assertSame($traceId, $span->traceId);
         $this->assertSame($parentSpanId, $span->parentId);
     }
@@ -222,8 +227,12 @@ class LoggerTest extends LoggerSubprocessTestCase
         $root = $log->createSpanLoggerFromTraceparent('request', "00-{$traceId}-" . bin2hex(random_bytes(8)) . '-01');
         $child = $root->createSpanLogger('login');
 
-        $this->assertSame($traceId, $child->getSpan()->traceId);
-        $this->assertSame($root->getSpan()->id, $child->getSpan()->parentId);
+        $rootSpan = $root->getSpan();
+        $childSpan = $child->getSpan();
+        $this->assertNotNull($rootSpan);
+        $this->assertNotNull($childSpan);
+        $this->assertSame($traceId, $childSpan->traceId);
+        $this->assertSame($rootSpan->id, $childSpan->parentId);
     }
 
     public function testCreateSpanLoggerFromTraceparentFallsBackOnMissingHeader(): void
@@ -232,6 +241,7 @@ class LoggerTest extends LoggerSubprocessTestCase
         $root = $log->createSpanLoggerFromTraceparent('request', null);
 
         $span = $root->getSpan();
+        $this->assertNotNull($span);
         $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $span->traceId);
         $this->assertNull($span->parentId);
     }
@@ -244,6 +254,7 @@ class LoggerTest extends LoggerSubprocessTestCase
         $log = new Logger('svc');
         foreach (['garbage', '00-tooshort-abc-01', $allZeroTrace, $allZeroSpan] as $bad) {
             $span = $log->createSpanLoggerFromTraceparent('request', $bad)->getSpan();
+            $this->assertNotNull($span, "header: {$bad}");
             $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $span->traceId, "header: {$bad}");
             $this->assertNull($span->parentId, "header: {$bad}");
         }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -248,11 +248,23 @@ class LoggerTest extends LoggerSubprocessTestCase
 
     public function testCreateSpanLoggerFromTraceparentFallsBackOnInvalidHeader(): void
     {
-        $allZeroTrace = '00-' . str_repeat('0', 32) . '-' . bin2hex(random_bytes(8)) . '-01';
-        $allZeroSpan = '00-' . bin2hex(random_bytes(16)) . '-' . str_repeat('0', 16) . '-01';
+        // trace/span are well-formed; only the version or field count is wrong,
+        // so these probe the W3C-conformance guards rather than the hex checks.
+        $trace = bin2hex(random_bytes(16));
+        $spanId = bin2hex(random_bytes(8));
+
+        $headers = [
+            'garbage',
+            '00-tooshort-abc-01',
+            '00-' . str_repeat('0', 32) . "-{$spanId}-01",   // all-zero trace
+            "00-{$trace}-" . str_repeat('0', 16) . '-01',     // all-zero span
+            "00-{$trace}-{$spanId}-01-extra",                 // version 00 must have exactly 4 fields
+            "ff-{$trace}-{$spanId}-01",                       // 'ff' is a reserved/invalid version
+            "zz-{$trace}-{$spanId}-01",                       // non-hex version
+        ];
 
         $log = new Logger('svc');
-        foreach (['garbage', '00-tooshort-abc-01', $allZeroTrace, $allZeroSpan] as $bad) {
+        foreach ($headers as $bad) {
             $span = $log->createSpanLoggerFromTraceparent('request', $bad)->getSpan();
             $this->assertNotNull($span, "header: {$bad}");
             $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $span->traceId, "header: {$bad}");

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -191,4 +191,61 @@ class LoggerTest extends LoggerSubprocessTestCase
         $this->assertNotNull($innerSpan);
         $this->assertSame($outerSpan->id, $innerSpan->parentId);
     }
+
+    public function testNestedSpanLoggerInheritsParentTraceId(): void
+    {
+        $log = new Logger('svc');
+        $outer = $log->createSpanLogger('outer');
+        $inner = $outer->createSpanLogger('inner');
+
+        $this->assertSame($outer->getSpan()->traceId, $inner->getSpan()->traceId);
+    }
+
+    public function testCreateSpanLoggerFromTraceparentAdoptsTraceIdAndParentSpanId(): void
+    {
+        $traceId = bin2hex(random_bytes(16));
+        $parentSpanId = bin2hex(random_bytes(8));
+
+        $log = new Logger('svc');
+        $root = $log->createSpanLoggerFromTraceparent('request', "00-{$traceId}-{$parentSpanId}-01");
+
+        $span = $root->getSpan();
+        $this->assertSame($traceId, $span->traceId);
+        $this->assertSame($parentSpanId, $span->parentId);
+    }
+
+    public function testTraceparentRootedChildSpanSharesIncomingTraceId(): void
+    {
+        $traceId = bin2hex(random_bytes(16));
+
+        $log = new Logger('svc');
+        $root = $log->createSpanLoggerFromTraceparent('request', "00-{$traceId}-" . bin2hex(random_bytes(8)) . '-01');
+        $child = $root->createSpanLogger('login');
+
+        $this->assertSame($traceId, $child->getSpan()->traceId);
+        $this->assertSame($root->getSpan()->id, $child->getSpan()->parentId);
+    }
+
+    public function testCreateSpanLoggerFromTraceparentFallsBackOnMissingHeader(): void
+    {
+        $log = new Logger('svc');
+        $root = $log->createSpanLoggerFromTraceparent('request', null);
+
+        $span = $root->getSpan();
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $span->traceId);
+        $this->assertNull($span->parentId);
+    }
+
+    public function testCreateSpanLoggerFromTraceparentFallsBackOnInvalidHeader(): void
+    {
+        $allZeroTrace = '00-' . str_repeat('0', 32) . '-' . bin2hex(random_bytes(8)) . '-01';
+        $allZeroSpan = '00-' . bin2hex(random_bytes(16)) . '-' . str_repeat('0', 16) . '-01';
+
+        $log = new Logger('svc');
+        foreach (['garbage', '00-tooshort-abc-01', $allZeroTrace, $allZeroSpan] as $bad) {
+            $span = $log->createSpanLoggerFromTraceparent('request', $bad)->getSpan();
+            $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $span->traceId, "header: {$bad}");
+            $this->assertNull($span->parentId, "header: {$bad}");
+        }
+    }
 }

--- a/tests/SpanTest.php
+++ b/tests/SpanTest.php
@@ -61,6 +61,16 @@ class SpanTest extends TestCase
         $this->assertArrayNotHasKey('parentSpanId', $record);
     }
 
+    public function testProvidedTraceIdIsUsedInsteadOfGenerated(): void
+    {
+        $traceId = bin2hex(random_bytes(16));
+        $span = new Span('op', 'svc', null, null, null, $traceId);
+
+        $this->assertSame($traceId, $span->traceId);
+        $record = $span->payload['resourceSpans'][0]['scopeSpans'][0]['spans'][0];
+        $this->assertSame($traceId, $record['traceId']);
+    }
+
     public function testTimestampsCarrySubSecondPrecision(): void
     {
         // Pre-fix bug: `(int)microtime(true) * 1e9` truncated to whole seconds


### PR DESCRIPTION
Spans now join the trace started by the reverse-proxy instead of starting a detached one.

- `Span`: optional `traceId` constructor arg; generated when omitted (unchanged default).
- `Logger::createSpanLoggerFromTraceparent(name, ?traceparent, ?context)`: parses/validates the W3C header (32-hex trace-id, 16-hex span-id, both non-zero) and roots the span on the incoming trace-id + proxy span-id. Missing/malformed headers fall back to a fresh trace without throwing.
- Nested `createSpanLogger` spans inherit the parent's trace-id.

Bumped to 0.5.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Functionality Changes

- Reverse-proxy trace linking: spans can join an incoming W3C traceparent so PHP spans become part of the proxy-initiated trace instead of creating detached traces.
- Optional trace ID propagation: Span construction accepts an optional traceId; when provided the span uses it instead of generating a new one.
- W3C traceparent parsing & strict validation: new parsing enforces version rules and exact field lengths (32-hex trace-id, 16-hex span-id), rejects all-zero ids and rejects trailing fields for version 00 and reserved/invalid version values.
- Silent graceful fallback: missing or malformed traceparent values do not throw — the logger creates a fresh trace (nil parent, newly generated traceId).
- Trace ID propagation across nested spans: nested createSpanLogger() calls inherit the parent's traceId so the entire request stays in a single trace.
- Documentation and versioning: README/changelog updated and package version bumped to 0.5.0.

## File-by-File Changes

README.md
- Added "Linking to an incoming trace (traceparent)" usage docs for Logger::createSpanLoggerFromTraceparent(), describing header format, validation rules (32-hex trace-id, 16-hex span-id, non-zero), the strict version/field semantics, silent fallback behavior, and that nested createSpanLogger calls inherit the parent's trace-id.
- Updated changelog section with 0.5.0 entry describing the traceparent linking and trace-id inheritance.

composer.json
- Bumped package version from 0.4.0 → 0.5.0.

src/Classes/Logger.php
- Added public createSpanLoggerFromTraceparent(string $name, ?string $traceparent = null, ?array $context = null): Logger which:
  - Parses and validates a W3C traceparent header and, when valid, roots the created span on the incoming traceId and uses the incoming spanId as the new span's parentId.
  - Falls back to creating a fresh root span (no exception) when header is missing or invalid.
- Added private static parseTraceparent(?string $traceparent): ?array that:
  - Enforces format version-traceId-spanId-flags.
  - Validates version is a 2-hex value and not reserved (ff); for version 00 rejects extra/trailing fields.
  - Validates traceId matches /^[0-9a-f]{32}$/ and is not all-zero.
  - Validates spanId matches /^[0-9a-f]{16}$/ and is not all-zero.
  - Returns parsed ['traceId'=>..., 'spanId'=>...] or null on invalid input.
- Modified createSpanLogger(string $name, ?array $context = null): Logger to propagate the current span's traceId into newly created Span instances so nested loggers preserve trace correlation.
- Existing logger plumbing otherwise unchanged; behavior intentionally falls back silently on invalid traceparent.

src/Classes/Span.php
- Constructor signature extended to accept optional ?OtlpSender $otlpSender = null and ?string $traceId = null.
- When a traceId is provided, the Span uses it (reflected in Span->traceId and emitted OTLP payload); otherwise a new 32-hex traceId is generated as before.
- Parent spanId handling and payload assembly remain unchanged aside from honoring provided traceId.

tests/LoggerTest.php
- Added tests covering:
  - Nested span loggers inherit the parent's traceId.
  - createSpanLoggerFromTraceparent adopts a valid traceparent's traceId and parent spanId.
  - Child spans created from a traceparent-rooted logger share the incoming traceId while linking the incoming spanId as parentId.
  - Fallback behavior when traceparent is null or invalid (including garbage, too-short inputs, all-zero ids, extra-field traceparent, reserved/invalid version values like `ff`, and non-hex version tokens).
- Test suite confirmed green across PHP 7.4 / 8.3 / 8.5 (62 tests / 195 assertions).

tests/SpanTest.php
- Added test ensuring a provided traceId passed to Span::__construct is used instead of generating a new one and is present in the emitted OTLP payload.

CHANGELOG / release notes
- Changelog entry added for v0.5.0 documenting traceparent linking, stricter validation, trace-id propagation, and the package version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->