### PR TITLE
TW-12626 - Inherit central CodeRabbit config via remote_config

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,5 @@
+# Inherit Timewave's central CodeRabbit config.
+remote_config:
+  repository: "Timewave-AB/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yml"


### PR DESCRIPTION
Adds a .coderabbit.yml that inherits Timewave's central CodeRabbit config via remote_config.